### PR TITLE
Remove spurious library; fix stability bug in alarm trigger

### DIFF
--- a/Code/ArduinoOnRampRed2.ino
+++ b/Code/ArduinoOnRampRed2.ino
@@ -2,7 +2,7 @@
 #include <NewTone.h>
 // include SPI, MP3, Servo and SD libraries
 #include <SPI.h>             // We will use the hardware SPI pins: CLK (13), MISO (12), MOSI (11)
-#include "Adafruit_VS1053.h"
+// #include "Adafruit_VS1053.h"  // This library is not needed -- CHS
 #include <SD.h>
 #include <Adafruit_NeoPixel.h>
 #ifdef __AVR__
@@ -58,7 +58,7 @@ void loop(){
       unsigned int uS = sonar.ping(); // Send ping, get ping time in microseconds (uS).
       unsigned int distance = uS / US_ROUNDTRIP_CM;
       Serial.println(distance);
-      if(distance < 10){
+      if( (distance) && (distance < 10)) { // sonar.ping() gives 0 distances occasionally (CHS)
          triggered = true;
       }
    }


### PR DESCRIPTION
The "Adafruit_VS1053.h" header references a library for a cool little music-playing board which, alas, we're not using in the class.  You no doubt had the library loaded on your machine and left the reference in 'cause it wasn't erroring.  Students won't have it.

I found that the ultrasound sensor was occasionally returning a distance of "0".  Triggering it at 50 msec intervals meant that the alarm would go off spontaneously about once every 5 or 10 seconds.  I added a check for 0 in the trigger part of the code, and it worked much better.